### PR TITLE
chore: use supported oidc provider

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -42,11 +42,32 @@ upstream:
       - kubernetes-sa-token
       - oauth-client
     appConfig:
+      app:
+        title: Red Hat Developer Hub
+        baseUrl: https://{{ backstage_host }}
+      backend:
+        baseUrl: https://{{ backstage_host }}
+        cors:
+          origin: https://{{ backstage_host }}
+        auth:
+          keys:
+            - secret:
+                $env: BACKEND_SECRET
       auth:
+        session:
+          secret: ${BACKEND_SECRET}
         environment: production
         providers:
-          oauth2Proxy: {}
-      signInPage: oauth2Proxy
+          oidc:
+            production:
+              prompt: auto
+              metadataUrl: https://{{ keycloak_host }}/realms/{{ keycloak_realm }}/.well-known/openid-configuration
+              clientId: ${OAUTH_CLIENT_ID}
+              clientSecret: ${OAUTH_CLIENT_SECRET}
+              signIn:
+                resolvers:
+                  - resolver: preferredUsernameMatchingUserEntityName
+      signInPage: oidc
       integrations:
         gitlab:
           - apiBaseUrl: https://{{ gitlab_host }}/api/v4
@@ -108,41 +129,9 @@ upstream:
         value: {{ backstage_backend_secret }}
       - name: NODE_TLS_REJECT_UNAUTHORIZED
         value: "0"
-    extraContainers:
-      - name: oauth2-proxy
-        env:
-          - name: OAUTH2_PROXY_CLIENT_ID
-            valueFrom:
-              secretKeyRef:
-                name: oauth-client
-                key: OAUTH_CLIENT_ID
-          - name: OAUTH2_PROXY_CLIENT_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: oauth-client
-                key: OAUTH_CLIENT_SECRET
-          - name: OAUTH2_PROXY_COOKIE_SECRET
-            value: {{ oauth2_proxy_cookie_secret }}
-          - name: OAUTH2_PROXY_OIDC_ISSUER_URL
-            value: {{ oauth2_proxy_oidc_issuer }}
-          - name: OAUTH2_PROXY_SSL_INSECURE_SKIP_VERIFY
-            value: 'true'
-        ports:
-          - name: oauth2-proxy
-            containerPort: 4180
-            protocol: TCP
-        imagePullPolicy: IfNotPresent
-        image: 'quay.io/oauth2-proxy/oauth2-proxy:latest'
-        args:
-          - '--provider=oidc'
-          - '--email-domain=*'
-          - '--upstream=http://localhost:7007'
-          - '--http-address=0.0.0.0:4180'
-          - '--skip-provider-button'
-          - '--insecure-oidc-allow-unverified-email=true'
   service:
     ports:
-      backend: 4180
-      targetPort: oauth2-proxy
+      backend: 7007
+      targetPort: backend
 route:
   host: {{ backstage_host }}

--- a/values.yaml
+++ b/values.yaml
@@ -42,17 +42,6 @@ upstream:
       - kubernetes-sa-token
       - oauth-client
     appConfig:
-      app:
-        title: Red Hat Developer Hub
-        baseUrl: https://{{ backstage_host }}
-      backend:
-        baseUrl: https://{{ backstage_host }}
-        cors:
-          origin: https://{{ backstage_host }}
-        auth:
-          keys:
-            - secret:
-                $env: BACKEND_SECRET
       auth:
         session:
           secret: ${BACKEND_SECRET}

--- a/values.yaml
+++ b/values.yaml
@@ -42,21 +42,29 @@ upstream:
       - kubernetes-sa-token
       - oauth-client
     appConfig:
+      # ============ AUTHENTICATION ============ #
+      # This is a development and testing authentication configuration
       auth:
-        session:
-          secret: ${BACKEND_SECRET}
-        environment: production
         providers:
-          oidc:
-            production:
-              prompt: auto
-              metadataUrl: https://{{ keycloak_host }}/realms/{{ keycloak_realm }}/.well-known/openid-configuration
-              clientId: ${OAUTH_CLIENT_ID}
-              clientSecret: ${OAUTH_CLIENT_SECRET}
-              signIn:
-                resolvers:
-                  - resolver: preferredUsernameMatchingUserEntityName
-      signInPage: oidc
+          guest:
+            dangerouslyAllowOutsideDevelopment: true
+      # Configuration required to enable OpenID Connect authentication
+      # auth:
+      #   session:
+      #     secret: ${BACKEND_SECRET}
+      #   environment: production
+      #   providers:
+      #     oidc:
+      #       production:
+      #         prompt: auto
+      #         metadataUrl: https://{{ keycloak_host }}/realms/{{ keycloak_realm }}/.well-known/openid-configuration
+      #         clientId: ${OAUTH_CLIENT_ID}
+      #         clientSecret: ${OAUTH_CLIENT_SECRET}
+      #         signIn:
+      #           resolvers:
+      #             - resolver: preferredUsernameMatchingUserEntityName
+      # signInPage: oidc
+      # ============ AUTHENTICATION ============ #
       integrations:
         gitlab:
           - apiBaseUrl: https://{{ gitlab_host }}/api/v4
@@ -68,17 +76,19 @@ upstream:
           - allow: [Component, System, API, Resource, Location, Template]
         locations: []
         providers:
-          keycloakOrg:
-            default:
-              baseUrl: https://{{ keycloak_host }}
-              realm: {{ keycloak_realm }}
-              loginRealm: {{ keycloak_login_realm }}
-              clientId: {{ keycloak_client_id }}
-              clientSecret: {{ keycloak_client_secret }}
-              schedule:
-                frequency: { minutes: 2 }
-                timeout: { minutes: 1 }
-                initialDelay: { seconds: 15 }
+          # ============ CATALOG PROVIDERS ============
+          # keycloakOrg:
+          #   default:
+          #     baseUrl: https://{{ keycloak_host }}
+          #     realm: {{ keycloak_realm }}
+          #     loginRealm: {{ keycloak_login_realm }}
+          #     clientId: {{ keycloak_client_id }}
+          #     clientSecret: {{ keycloak_client_secret }}
+          #     schedule:
+          #       frequency: { minutes: 2 }
+          #       timeout: { minutes: 1 }
+          #       initialDelay: { seconds: 15 }
+          # ============ CATALOG PROVIDERS ============
       techdocs:
         builder: 'local'
         publisher:


### PR DESCRIPTION
The oauth2proxy is not officially documented and supported. It also breaks the logout flow, and API interactions using static tokens from tools such as the Orchestrator. Switching to the OIDC provider resolves these issues.