### PR TITLE
chroe: remove rbac to test template failure

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -175,17 +175,6 @@ upstream:
           - group: 'tekton.dev'
             apiVersion: 'v1beta1'
             plural: 'taskruns'
-      
-      ## --- RBAC --- #
-      # permission:
-      #   enabled: true
-      #   rbac:
-      #     admin:
-      #       users:
-      #         - name: user:default/pe1
-      #         - name: user:default/pe2
-      #     policies-csv-file: ./rbac/rbac-policy.csv
-      ## --- RBAC --- #
 
     extraEnvVars:
       - name: NODE_OPTIONS
@@ -194,44 +183,6 @@ upstream:
         value: {{ backstage_backend_secret }}
       - name: NODE_TLS_REJECT_UNAUTHORIZED
         value: "0"
-    
-    ## --- RBAC --- #
-    # extraVolumeMounts:
-    #   - name: dynamic-plugins-root
-    #     mountPath: /opt/app-root/src/dynamic-plugins-root
-    #   - name: audit-log-data
-    #     mountPath: /var/log/audit
-    #   - name: rbac-policy
-    #     mountPath: opt/app-root/src/rbac
-    # extraVolumes:
-    #   - name: dynamic-plugins-root
-    #     persistentVolumeClaim:
-    #       claimName: '{{ printf "%s-dynamic-plugins-root" .Release.Name }}'
-    #   - name: audit-log-data
-    #     persistentVolumeClaim:
-    #       claimName: '{{ printf "%s-audit-log" .Release.Name }}'
-    #   - name: dynamic-plugins
-    #     configMap:
-    #       defaultMode: 420
-    #       name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
-    #       optional: true
-    #   - name: dynamic-plugins-npmrc
-    #     secret:
-    #       defaultMode: 420
-    #       optional: true
-    #       secretName: '{{ printf "%s-dynamic-plugins-npmrc" .Release.Name }}'
-    #   - name: dynamic-plugins-registry-auth
-    #     secret:
-    #       defaultMode: 416
-    #       optional: true
-    #       secretName: '{{ printf "%s-dynamic-plugins-registry-auth" .Release.Name }}'
-    #   - name: npmcacache
-    #     emptyDir: {}
-    #   - name: rbac-policy
-    #     configMap:
-    #       name: rbac-policy
-    #       defaultMode: 420
-    ## --- RBAC --- #
 
   service:
     ports:


### PR DESCRIPTION
CC @jayachristina I had to remove these in my GitLab and restart the rhdh-config-template in the backstage-bootstrap in GitOps to get Backstage deployed