### PR TITLE
adding projectPattern for Gitlab Autodiscovery

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -111,6 +111,7 @@ upstream:
           #     fallbackBranch: master
           #     skipForkedRepos: true
           #     entityFilename: catalog-info.yaml
+          #     projectPattern: \w*techdocs\w*
           #     schedule:
           #       frequency: { minutes: 2 }
           #       timeout: { minutes: 3 }


### PR DESCRIPTION
To only autodiscover repos with word techdocs in it.
Added a pattern and tested too @evanshortiss 
Can you please check this out 